### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server that provides access to NS (Dutch Railways) travel information.
 
+<a href="https://glama.ai/mcp/servers/tzd5oz5tov"><img width="380" height="200" src="https://glama.ai/mcp/servers/tzd5oz5tov/badge" alt="NS Travel Information Server MCP server" /></a>
+
 ## Setup
 
 1. Clone this repository


### PR DESCRIPTION
This PR adds a badge for the NS Travel Information MCP Server server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/tzd5oz5tov

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.