### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,5 @@ COPY --from=builder /app/package-lock.json /app/package-lock.json
 # Install only production dependencies
 RUN npm ci --omit=dev
 
-# Environment variables
-ENV NS_API_KEY=your_api_key_here
-
 # Define the command to run the application
 ENTRYPOINT ["node", "build/index.js"]


### PR DESCRIPTION
I got this error while running Docker

 1 warning found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "NS_API_KEY") (line 30) Dockerfile:27

Since you already have it in the .env.example there is no need for hardcoding it in the Dockerfile